### PR TITLE
Replaced deprecated import with new one

### DIFF
--- a/flask_shell2http/classes.py
+++ b/flask_shell2http/classes.py
@@ -7,7 +7,7 @@ import shutil
 from typing import List, Dict, Tuple, Any, Optional
 
 # web imports
-from flask.helpers import safe_join
+from werkzeug.utils import safe_join
 from werkzeug.utils import secure_filename
 from flask_executor.futures import Future
 


### PR DESCRIPTION
New Flask versions cause the following error:
```
ImportError: cannot import name 'safe_join' from 'flask.helpers' (/root/.local/lib/python3.9/site-packages/flask/helpers.py)
```

It looks to have been deprecated and shifted to werkzeug:
https://github.com/pallets/flask/pull/4337