### PR TITLE
Fixes #42: ImportError for `safe_join`

### DIFF
--- a/flask_shell2http/classes.py
+++ b/flask_shell2http/classes.py
@@ -7,8 +7,7 @@ import shutil
 from typing import List, Dict, Tuple, Any, Optional
 
 # web imports
-from flask.helpers import safe_join
-from werkzeug.utils import secure_filename
+from werkzeug.utils import secure_filename, safe_join 
 from flask_executor.futures import Future
 
 # lib imports


### PR DESCRIPTION
Not really sure if this breaks something else, please verify

- Fixed Import Error caused by regression from Flask version 2.1.0 update