### PR TITLE
docs: fix successful spelling in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ A minimalist Flask_ extension that serves as a RESTful/HTTP wrapper for python's
 
 **Use Cases:**
 
-- Set a script that runs on a succesful POST request to an endpoint of your choice.
+- Set a script that runs on a successful POST request to an endpoint of your choice.
 - Map a base command to an endpoint and pass dynamic arguments to it.
 - Can also process multiple uploaded files in one command.
 - This is useful for internal docker-to-docker communications if you have different binaries distributed in micro-containers.


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `docs/source/index.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
